### PR TITLE
Improve FFT denoise algorithms

### DIFF
--- a/ALOE_2025_05_17/modules/DENOISE_FFT/src/DENOISE_FFT_functions.h
+++ b/ALOE_2025_05_17/modules/DENOISE_FFT/src/DENOISE_FFT_functions.h
@@ -23,7 +23,7 @@
 #ifndef _FUNCTIONS_H
 #define _FUNCTIONS_H
 void low_pass_filter(fftw_complex *X, size_t N, float fc_norm, float tb_norm, int dbg);
-void amplitude_threshold(fftw_complex *X, size_t N, float threshold, int dbg);
+void amplitude_threshold(fftw_complex *X, size_t N, float thr_factor, int dbg);
 void emd_filter(fftw_complex *X, size_t N, int dbg);
 
 #endif


### PR DESCRIPTION
## Summary
- rework amplitude thresholding to use median based noise estimation
- add simple data carrier detection helper
- tighten the EMD-lite filter bypass criterion
- expose updated parameter name in header

## Testing
- `make -C ALOE_2025_05_17/modules/DENOISE_FFT/lnx_make` *(fails: missing aclocal)*

------
https://chatgpt.com/codex/tasks/task_e_684411fc635c83258544792e673cde89